### PR TITLE
fixed bug where deleting first frame was failing

### DIFF
--- a/js/piskel.js
+++ b/js/piskel.js
@@ -183,7 +183,8 @@ $.namespace("pskl");
 
     removeFrame: function(frameIndex) {     
       frameSheet.removeFrameByIndex(frameIndex);
-      this.setActiveFrameAndRedraw(frameIndex - 1);
+      var activeFrameIndex = frameIndex ? frameIndex - 1 : 0;
+      this.setActiveFrameAndRedraw(activeFrameIndex);
     },
 
     duplicateFrame: function(frameIndex) {


### PR DESCRIPTION
When deleting the first frame, frameIndex-1 was -1, therefore failing the rest of the process
