### PR TITLE
correct slider init value and better FX slider event handling

### DIFF
--- a/js/controller/AnimatedPreviewController.js
+++ b/js/controller/AnimatedPreviewController.js
@@ -18,15 +18,19 @@
     };
 
     ns.AnimatedPreviewController.prototype.init = function () {
-        $("#preview-fps")[0].addEventListener('change', this.onFPSSliderChange.bind(this));
+        // the oninput event won't work on IE10 unfortunately, but at least will provide a
+        // consistent behavior across all other browsers that support the input type range
+        // see https://bugzilla.mozilla.org/show_bug.cgi?id=853670
+        $("#preview-fps")[0].addEventListener('input', this.onFPSSliderChange.bind(this));
     };
 
-    ns.AnimatedPreviewController.prototype.onFPSSliderChange = function(evt) {
+    ns.AnimatedPreviewController.prototype.onFPSSliderChange = function (evt) {
         this.setFPS(parseInt($("#preview-fps")[0].value, 10));
     };
 
     ns.AnimatedPreviewController.prototype.setFPS = function (fps) {
         this.fps = fps;
+        $("#preview-fps").val(this.fps);
         $("#display-fps").html(this.fps + " FPS");
     };
 


### PR DESCRIPTION
Trying to fix issue https://github.com/juliandescottes/piskel/issues/98
2 changes done:
- Setting the value of the range input in the setFPS function so that loading existing framesheets from a service actually sets the slider correctly
- Changing the onchange event listener to oninput in order to change the FPS value while dragging on all browsers (namely on FX)
