### PR TITLE
Exclude add-frame-button from sortable items in preview-film

### DIFF
--- a/js/controller/PreviewFilmController.js
+++ b/js/controller/PreviewFilmController.js
@@ -94,11 +94,11 @@
      * @private
      */
     ns.PreviewFilmController.prototype.initDragndropBehavior_ = function () {
-
+        
         $("#preview-list").sortable({
           placeholder: "preview-tile-drop-proxy",
           update: $.proxy(this.onUpdate_, this),
-          items: "li:not(#add-frame-action)"
+          items: ".preview-tile"
         });
         $("#preview-list").disableSelection();
     };


### PR DESCRIPTION
Small bug fixing : The add-frame-button is in the UL preview-list, on which we apply a jQuery.sortable. Therefore, the add frame button was draggable.

This item has been excluded using http://jqueryui.com/sortable/#items 
