### PR TITLE
Allow to rename basename for PNG in ZIP export option.

### DIFF
--- a/src/js/controller/settings/PngExportController.js
+++ b/src/js/controller/settings/PngExportController.js
@@ -30,7 +30,8 @@
     for (var i = 0; i < this.piskelController.getFrameCount(); i++) {
       var frame = this.piskelController.getFrameAt(i);
       var canvas = this.getFrameAsCanvas_(frame);
-      var filename = "sprite_" + (i+1) + ".png";
+      var basename = document.getElementById("zip-file-name").value || "sprite_";
+      var filename =  basename + (i+1) + ".png";
       zip.file(filename, pskl.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
     }
 

--- a/src/templates/settings/export.html
+++ b/src/templates/settings/export.html
@@ -7,11 +7,16 @@
     <span class="settings-description">PNG with all frames side by side.</span>
     <button type="button" class="button button-primary png-download-button">Download PNG</button>
   </div>
+  <div class="settings-title">
+    Export as ZIP
+  </div>
   <div class="settings-item">
-    <span class="settings-description">ZIP with one PNG file per frame.</span>
-    <div>
-      <button type="button" class="button button-primary zip-generate-button"/>Download ZIP</button>
+    <span class="settings-description">ZIP with one PNG file per frame. Name will use the prefix above and append the frame index, ex: sprite_1.png</span>
+    <div class="settings-item">
+      <label for="zip-file-name">File prefix:</label>
+      <input id="zip-file-name" type="text" class="textfield" placeholder="sprite_">
     </div>
+    <button type="button" class="button button-primary zip-generate-button"/>Download ZIP</button>
   </div>
   <div class="settings-title">
     Export to Animated GIF


### PR DESCRIPTION
When using texturepackers the name of the file is important as it will be used to generate data.

Currently pixel names all png exported in ZIP to `sprite_x.png`. I wanted to use the `#save-name` field but I realized your current setup is not saving text inputs so I added one.

Tell me what do you think about it and feel free to change the text I added.
