### PR TITLE
Combining oninput and onchange events for the FPS counter. Close #225

### DIFF
--- a/src/js/controller/AnimatedPreviewController.js
+++ b/src/js/controller/AnimatedPreviewController.js
@@ -22,7 +22,7 @@
     // the oninput event won't work on IE10 unfortunately, but at least will provide a
     // consistent behavior across all other browsers that support the input type range
     // see https://bugzilla.mozilla.org/show_bug.cgi?id=853670
-    $("#preview-fps")[0].addEventListener('change', this.onFPSSliderChange.bind(this));
+    $("#preview-fps").on('input change', this.onFPSSliderChange.bind(this));
     document.querySelector(".right-column").style.width = Constants.ANIMATED_PREVIEW_WIDTH + 'px';
 
     this.toggleOnionSkinEl = document.querySelector(".preview-toggle-onion-skin");


### PR DESCRIPTION
`oninput` dosen't supported in IE10 for range element. However `onchange` event in IE10 works as `oninput` event for other browsers.
