### PR TITLE
Fix #690 - remove references to github/juliandescottes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,21 @@
 Piskel
 ======
 
-[![Travis Status](https://api.travis-ci.org/juliandescottes/piskel.png?branch=master)](https://travis-ci.org/juliandescottes/piskel) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
+[![Travis Status](https://api.travis-ci.org/piskelapp/piskel.png?branch=master)](https://travis-ci.org/piskelapp/piskel) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 
-A simple web-based tool for Spriting and Pixel art.
+Piskel is an easy-to-use sprite editor. It can be used to create game sprites, animations, pixel-art...
+It is the editor used in **[piskelapp.com](http://piskelapp.com)**.
 
-![Piskel editor screenshot](https://screenletstore.appspot.com/img/8f03e768-ac59-11e3-b2a1-7f5a1b97c420.jpeg "Piskel editor screenshot")
+<img
+  src="https://screenletstore.appspot.com/img/95aaa0f0-37a4-11e7-a652-7b8128ce3e3b.png"
+  title="Piskel editor screenshot"
+  width="500">
 
-You can try the standalone editor at **http://juliandescottes.github.io/piskel** or see it integrated in **http://piskelapp.com**.
+## About Piskel
 
-Piskel is mainly developped by :
+### Built with
 
-* **[@juliandescottes](https://github.com/juliandescottes)**
-* **[@grosbouddha](https://github.com/grosbouddha)**
-
-## What's the point ?
-
-You can use Piskel to do two things :
-* **spriting** : create retro-style sprites for games
-
-![Megaman spritesheet](http://piskel-imgstore-a.appspot.com/img/c8081287-ac58-11e3-bd8c-b3c4036c0eee.png "Megaman spritesheet")
-
-* **pixelart** : create crazy/pretty pixelart animations for fun !
-
-![Rabbit jumping](http://piskel-imgstore-a.appspot.com/img/947f2dab-ac58-11e3-949a-b3c4036c0eee.gif "Rabit jumping")
-
-Integrated in **[piskelapp.com](http://piskelapp.com)**, you can share everything you work on with others as easily as you share a link.
-
-## Requirements
-
-Piskel supports the following browsers :
-* **Chrome** (latest)
-* **Firefox** (latest)
-* **Internet Explorer** 11+
-
-... and a fairly recent computer.
-
-We don't plan/want/could be forced into supporting older IEs. For Opera and Safari, we've never tested them but the gap shouldn't be huge.
-
-## Offline version
-
-Offline builds are available. More details in the [dedicated wiki page](https://github.com/juliandescottes/piskel/wiki/Desktop-applications).
-
-## Built with
-
-The Piskel editor is purely built in **JavaScript, HTML and CSS**. It uses Canvas extensively for displaying all them pretty sprites.
+The Piskel editor is purely built in **JavaScript, HTML and CSS**.
 
 We also use the following **libraries** :
 * [spectrum](https://github.com/bgrins/spectrum) : awesome standalone colorpicker
@@ -59,13 +30,28 @@ As well as some **icons** from the [Noun Project](http://thenounproject.com/) :
 * Folder by Simple Icons from The Noun Project
 * (and probably one or two others)
 
+### Browser Support
+
+Piskel supports the following browsers:
+* **Chrome** (latest)
+* **Firefox** (latest)
+* **Edge** (latest)
+* **Internet Explorer** 11
+
+### Mobile/Tablets
+
+There is no support for mobile.
+
+### Offline builds
+
+Offline builds are available. More details in the [dedicated wiki page](https://github.com/piskelapp/piskel/wiki/Desktop-applications).
 
 ## Contributing ?
 
 Help is always welcome !
 
-* **Issues** : Found a problem when using the application, want to request a feature, [open an issue](https://github.com/juliandescottes/piskel/issues).
-* **Participate** : Have a look at the [wiki](https://github.com/juliandescottes/piskel/wiki) to set up the development environment
+* **Issues** : Found a problem when using the application, want to request a feature, [open an issue](https://github.com/piskelapp/piskel/issues).
+* **Development** : Have a look at the [wiki](https://github.com/piskelapp/piskel/wiki) to set up the development environment
 
 ## License
 
@@ -82,8 +68,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-## Mobile/Tablets
-
-There is no support for mobile for now.
 


### PR DESCRIPTION
Not perfect yet, but at least a bit cleaner.