### PR TITLE
Show drawing zoom level

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -86,6 +86,12 @@
   font-family:monospace;
 }
 
+.cursor-coordinates .drawing-zoom {
+  position: absolute;
+  top: -20px;
+  left: 1px;
+}
+
 /**
  * Canvases layout
  */

--- a/src/js/controller/CursorCoordinatesController.js
+++ b/src/js/controller/CursorCoordinatesController.js
@@ -17,6 +17,7 @@
     $.subscribe(Events.DRAG_START, this.onDragStart_.bind(this));
     $.subscribe(Events.DRAG_END, this.onDragEnd_.bind(this));
     $.subscribe(Events.FRAME_SIZE_CHANGED, this.redraw.bind(this));
+    $.subscribe(Events.ZOOM_CHANGED, this.redraw.bind(this));
 
     this.redraw();
   };
@@ -37,6 +38,11 @@
         var dY = Math.abs(y - this.origin.y) + 1;
         html += ' (' + dX + 'x' + dY + ')';
       }
+    }
+
+    if (pskl.app.drawingController) {
+      var zoom = pskl.app.drawingController.compositeRenderer.getZoom().toFixed(2);
+      html += '<div class="drawing-zoom">x' + zoom + '</div>';
     }
 
     this.coordinatesContainer.innerHTML = this.getFrameSizeHTML_() + html;


### PR DESCRIPTION
Option for displaying the current zoom level of the main drawing view (to resolve #627).

The zoom level would not fit nicely inline with the rest of the cursor coordinate info, so I landed on displaying it directly above.