### PR TITLE
Made cursor coordinates gold (and whitespace more consistent).

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -80,10 +80,10 @@
 }
 
 .cursor-coordinates {
-  color:#888;
-  font-size:12px;
-  font-weight:bold;
-  font-family:monospace;
+  color: gold;
+  font-size: 12px;
+  font-weight: bold;
+  font-family: monospace;
 }
 
 .cursor-coordinates .drawing-zoom {

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -80,7 +80,7 @@
 }
 
 .cursor-coordinates {
-  color: gold;
+  color: var(--highlight-color);
   font-size: 12px;
   font-weight: bold;
   font-family: monospace;


### PR DESCRIPTION
As [discussed][1] with @juliandescottes, I've made the cursor coordinates at the bottom of the editor UI gold so they stand out better.

The CSS file (`layout.css`) generally has spaces after the colon between property names and their values, like `name: value`, but the rule this edit applies to didn't have the spaces, like `name:value`, so I added spaces to all four lines, but only otherwise edited one of them.

[1]: https://github.com/piskelapp/piskel/issues/762