### PR TITLE
Use layer name as filename prefix in zip export

### DIFF
--- a/src/js/controller/settings/exportimage/ZipExportController.js
+++ b/src/js/controller/settings/exportimage/ZipExportController.js
@@ -15,16 +15,20 @@
     this.splitByLayersCheckbox = document.querySelector('.zip-split-layers-checkbox');
     this.addEventListener(this.splitByLayersCheckbox, 'change', this.onSplitLayersClick_);
 
-    this.useLayerNamesCheckboxContainer = document.querySelector('.use-layer-names-checkbox-container');
+    this.useLayerNamesContainer = document.querySelector('.use-layer-names-container');
     this.useLayerNamesCheckbox = document.querySelector('.zip-use-layer-names-checkbox');
-    this.useLayerNamesCheckboxContainer.hidden = !this.splitByLayersCheckbox.checked;
+    this.toggleHideUseLayerNamesCheckbox();
 
     var zipButton = document.querySelector('.zip-generate-button');
     this.addEventListener(zipButton, 'click', this.onZipButtonClick_);
   };
 
+  ns.ZipExportController.prototype.toggleHideUseLayerNamesCheckbox = function () {
+    this.useLayerNamesContainer.style.display = (this.splitByLayersCheckbox.checked ? 'block' : 'none');
+  };
+
   ns.ZipExportController.prototype.onSplitLayersClick_ = function () {
-    this.useLayerNamesCheckboxContainer.hidden = !this.splitByLayersCheckbox.checked;
+    this.toggleHideUseLayerNamesCheckbox();
   };
 
   ns.ZipExportController.prototype.onZipButtonClick_ = function () {

--- a/src/js/controller/settings/exportimage/ZipExportController.js
+++ b/src/js/controller/settings/exportimage/ZipExportController.js
@@ -12,10 +12,19 @@
     this.pngFilePrefixInput = document.querySelector('.zip-prefix-name');
     this.pngFilePrefixInput.value = 'sprite_';
 
-    this.splitByLayersCheckbox =  document.querySelector('.zip-split-layers-checkbox');
+    this.splitByLayersCheckbox = document.querySelector('.zip-split-layers-checkbox');
+    this.addEventListener(this.splitByLayersCheckbox, 'change', this.onSplitLayersClick_);
+
+    this.useLayerNamesCheckboxContainer = document.querySelector('.use-layer-names-checkbox-container');
+    this.useLayerNamesCheckbox = document.querySelector('.zip-use-layer-names-checkbox');
+    this.useLayerNamesCheckboxContainer.hidden = !this.splitByLayersCheckbox.checked;
 
     var zipButton = document.querySelector('.zip-generate-button');
     this.addEventListener(zipButton, 'click', this.onZipButtonClick_);
+  };
+
+  ns.ZipExportController.prototype.onSplitLayersClick_ = function () {
+    this.useLayerNamesCheckboxContainer.hidden = !this.splitByLayersCheckbox.checked;
   };
 
   ns.ZipExportController.prototype.onZipButtonClick_ = function () {
@@ -63,6 +72,9 @@
         var basename = this.pngFilePrefixInput.value;
         var frameid = pskl.utils.StringUtils.leftPad(i + 1, framePaddingLength, '0');
         var filename = 'l' + layerid + '_' + basename + frameid + '.png';
+        if (this.useLayerNamesCheckbox.checked) {
+          filename = layer.getName() + '_' + basename + frameid + '.png';
+        }
         zip.file(filename, pskl.utils.CanvasUtils.getBase64FromCanvas(canvas) + '\n', {base64: true});
       }
     }

--- a/src/templates/settings/export/zip.html
+++ b/src/templates/settings/export/zip.html
@@ -11,6 +11,10 @@
         <input id="zip-split-layers" class="zip-split-layers-checkbox checkbox-fix" type="checkbox" />
         <label for="zip-split-layers">Split by layers</label>
       </div>
+      <div class="use-layer-names-checkbox-container" style="margin: 5px 0;">
+        <input id="zip-use-layer-names" class="zip-use-layer-names-checkbox checkbox-fix" type="checkbox" />
+        <label for="zip-use-layer-names">Index by layer names</label>
+      </div>
       <button type="button" class="button button-primary zip-generate-button"/>Download ZIP</button>
     </div>
   </div>

--- a/src/templates/settings/export/zip.html
+++ b/src/templates/settings/export/zip.html
@@ -11,7 +11,7 @@
         <input id="zip-split-layers" class="zip-split-layers-checkbox checkbox-fix" type="checkbox" />
         <label for="zip-split-layers">Split by layers</label>
       </div>
-      <div class="use-layer-names-checkbox-container" style="margin: 5px 0;">
+      <div class="checkbox-container use-layer-names-container" style="margin: 5px 0;">
         <input id="zip-use-layer-names" class="zip-use-layer-names-checkbox checkbox-fix" type="checkbox" />
         <label for="zip-use-layer-names">Index by layer names</label>
       </div>


### PR DESCRIPTION
Hi!

Piskel is such a great project; I use it all the time for making scenes and characters in my video games. Thanks for making this!

I'd like to have the exported layers optionally start with the layer name, rather than the layer index. For most of my games, I'm copying over the exported layers and frames from Piskel into another project, and then referencing them by filename in the game code. If I need to come back to Piskel and add another layer in the middle of others are re-export, my the existing layers' filenames are now shifted due to the index change and my game code's file references are wrong. Optionally using the layer name in the exported files rather than index would allow easier migration of files to other projects that aren't expecting layer file names to change each time.

I added a new checkbox to the zip export html template to enable this option, and supporting logic to the zip export controller. The new checkbox should not show unless the "split by layers" options is checked.

Let me know what you think.

Thanks again,
Alex 