### PR TITLE
Issue #840 - Fix grid space not updating until next action by forcing DOM regen

### DIFF
--- a/src/js/controller/FramesListController.js
+++ b/src/js/controller/FramesListController.js
@@ -28,7 +28,7 @@
   ns.FramesListController.prototype.init = function() {
     $.subscribe(Events.TOOL_RELEASED, this.flagForRedraw_.bind(this));
     $.subscribe(Events.PISKEL_RESET, this.flagForRedraw_.bind(this, true));
-    $.subscribe(Events.USER_SETTINGS_CHANGED, this.flagForRedraw_.bind(this));
+    $.subscribe(Events.USER_SETTINGS_CHANGED, this.flagForRedraw_.bind(this, true));
 
     $.subscribe(Events.PISKEL_RESET, this.refreshZoom_.bind(this));
 


### PR DESCRIPTION
A quick fix for #840, but could be overkill and have side-effects