### PR TITLE
Implementation for Issue #841

### DIFF
--- a/src/js/controller/LayersListController.js
+++ b/src/js/controller/LayersListController.js
@@ -130,6 +130,14 @@
       layerNameEl.setAttribute('title', layer.getName());
       layerNameEl.setAttribute('rel', 'tooltip');
     }
+    var opacity = layer.getOpacity();
+    if (opacity == 1) {
+      layerItem.querySelector('.layer-item-opacity').style.color = '#ffd700';
+    } else if (opacity == 0) {
+      layerItem.querySelector('.layer-item-opacity').style.color = '#969696';
+    } else {
+      layerItem.querySelector('.layer-item-opacity').style.color = '#ffffff';
+    }
   };
 
   ns.LayersListController.prototype.onClick_ = function (evt) {

--- a/src/templates/layers-list.html
+++ b/src/templates/layers-list.html
@@ -38,8 +38,8 @@
         data-layer-index="{{layerindex}}">
         <span class="layer-name" data-placement="top">{{layername}}</span>
         <span class="layer-item-opacity"
-              title="Layer opacity" rel="tooltip" data-placement="top">
-          {{opacity}}&#945;
+              title="Layer opacity ({{opacity}})" rel="tooltip" data-placement="top">
+            &#945;
         </span>
     </li>
   </script>


### PR DESCRIPTION
Hi again, in Issue #845 you said you wanted colors instead of numbers to represent opacity state. I made the changes along with a [video demo](https://www.dropbox.com/s/lf7shsw70knzlnx/Piskel%20%23%20Issue%20841%20v2.mp4?dl=0). This required only a minor change to **addLayerItem** in **LayerListController.js**. Once the layer item is created the style for the alpha icon color is added based on the current opacity for that layer. 

I used the following colors for opacity which match the color style of Piskel.
- Gold (#ffd700) for `α = 1` .
- White (#ffffff) for `0 < α < 1`.
- Grey (#969696) for `α = 0`.