### PR TITLE
add grunt-cli to devDependencies, fix nwjs start script, add serve and build commands

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,7 +87,10 @@ module.exports = function(grunt) {
         // Exludes
         // TODO: remove this (for now we still get warnings from the lib folder)
         '!src/js/**/lib/**/*.js'
-      ]
+      ],
+      options: {
+        fix: grunt.option('fix') // this will get params from the flags
+      }
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "./dest/prod/index.html",
   "scripts": {
     "test": "grunt test",
-    "start": "nodewebkit",
+    "start": "nw",
     "preversion": "grunt test build",
     "postversion": "git push && git push --tags && npm publish",
     "release": "grunt && node ./bin/copy-to-piskel-website"
@@ -54,6 +54,7 @@
     "karma-jasmine": "1.1.0",
     "karma-phantomjs-launcher": "1.0.4",
     "load-grunt-tasks": "3.5.0",
+    "nw": "^0.42.3",
     "phantomjs": "2.1.7",
     "phantomjs-polyfill-object-assign": "0.0.2",
     "promise-polyfill": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   "devDependencies": {
     "dateformat": "2.0.0",
     "fs-extra": "3.0.1",
-    "grunt": "0.4.5",
+    "grunt": "^0.4.5",
     "grunt-casperjs": "^2.2.1",
+    "grunt-cli": "^1.3.2",
     "grunt-contrib-clean": "1.1.0",
     "grunt-contrib-concat": "1.0.1",
     "grunt-contrib-connect": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "./dest/prod/index.html",
   "scripts": {
     "test": "grunt test",
-    "dev": "grunt serve",
+    "dev": "grunt play",
     "start": "grunt build && nw",
     "preversion": "grunt test build",
     "postversion": "git push && git push --tags && npm publish",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "postversion": "git push && git push --tags && npm publish",
     "release": "grunt && node ./bin/copy-to-piskel-website",
     "build": "grunt desktop",
-    "build:mac": "grunt desktop-mac"
+    "build:mac": "grunt desktop-mac",
+    "format": "grunt eslint --fix"
   },
   "devDependencies": {
     "dateformat": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "grunt test",
     "dev": "grunt serve",
-    "start": "nw",
+    "start": "grunt build && nw",
     "preversion": "grunt test build",
     "postversion": "git push && git push --tags && npm publish",
     "release": "grunt && node ./bin/copy-to-piskel-website",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,13 @@
   "main": "./dest/prod/index.html",
   "scripts": {
     "test": "grunt test",
+    "dev": "grunt serve",
     "start": "nw",
     "preversion": "grunt test build",
     "postversion": "git push && git push --tags && npm publish",
-    "release": "grunt && node ./bin/copy-to-piskel-website"
+    "release": "grunt && node ./bin/copy-to-piskel-website",
+    "build": "grunt desktop",
+    "build:mac": "grunt desktop-mac"
   },
   "devDependencies": {
     "dateformat": "2.0.0",


### PR DESCRIPTION
You cant build piskel without it, yet when you npm install, it's not installed. This kind of breaks the usual npm install, then run approach as the user has to then figure out why piskel is not building and what to do