### PR TITLE
Add ability to source all layers to bucket fill tool

### DIFF
--- a/src/js/tools/drawing/PaintBucket.js
+++ b/src/js/tools/drawing/PaintBucket.js
@@ -10,6 +10,8 @@
     this.toolId = 'tool-paint-bucket';
     this.helpText = 'Paint bucket tool';
     this.shortcut = pskl.service.keyboard.Shortcuts.TOOL.PAINT_BUCKET;
+
+    this.tooltipDescriptors = [{ key: 'ctrl', description: 'Source only current layer' }];
   };
 
   pskl.utils.inherit(ns.PaintBucket, ns.BaseTool);
@@ -19,7 +21,15 @@
    */
   ns.PaintBucket.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     var color = this.getToolColor();
-    pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(frame, col, row, color);
+    
+    var sourceOnlyCurrentLayer = pskl.utils.UserAgent.isMac ? event.metaKey : event.ctrlKey;
+    var sourceFrame = frame;
+    if (!sourceOnlyCurrentLayer) {
+      var currentFrameIndex = pskl.app.piskelController.getCurrentFrameIndex();
+      sourceFrame = pskl.utils.LayerUtils.mergeFrameAt(pskl.app.piskelController.getLayers(), currentFrameIndex);
+    };
+
+    pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(sourceFrame, frame, col, row, color);
 
     this.raiseSaveStateEvent({
       col : col,
@@ -29,6 +39,6 @@
   };
 
   ns.PaintBucket.prototype.replay = function (frame, replayData) {
-    pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(frame, replayData.col, replayData.row, replayData.color);
+    pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(frame, frame, replayData.col, replayData.row, replayData.color);
   };
 })();

--- a/src/js/utils/PixelUtils.js
+++ b/src/js/utils/PixelUtils.js
@@ -100,14 +100,15 @@
      * Apply the paintbucket tool in a frame at the (col, row) initial position
      * with the replacement color.
      *
-     * @param frame pskl.model.Frame The frame target in which we want to paintbucket
+     * @param sourceFrame pskl.model.Frame The frame source which we use for reference to discover pixels to fill. This is disposed.
+     * @param targetFrame pskl.model.Frame The frame target in which we want to paintbucket. We set color on this frame.
      * @param col number Column coordinate in the frame
      * @param row number Row coordinate in the frame
      * @param replacementColor string Hexadecimal color used to fill the area
      *
      * @return an array of the pixel coordinates paint with the replacement color
      */
-    paintSimilarConnectedPixelsFromFrame: function(frame, col, row, replacementColor) {
+    paintSimilarConnectedPixelsFromFrame: function(sourceFrame, targetFrame, col, row, replacementColor) {
       /**
        *  Queue linear Flood-fill (node, target-color, replacement-color):
        *   1. Set Q to the empty queue.
@@ -131,7 +132,7 @@
 
       var targetColor;
       try {
-        targetColor = frame.getPixel(col, row);
+        targetColor = sourceFrame.getPixel(col, row);
       } catch (e) {
         // Frame out of bound exception.
       }
@@ -144,9 +145,10 @@
         col : col,
         row : row
       };
-      var paintedPixels = pskl.PixelUtils.visitConnectedPixels(startPixel, frame, function (pixel) {
-        if (frame.getPixel(pixel.col, pixel.row) == targetColor) {
-          frame.setPixel(pixel.col, pixel.row, replacementColor);
+      var paintedPixels = pskl.PixelUtils.visitConnectedPixels(startPixel, sourceFrame, function (pixel) {
+        if (sourceFrame.getPixel(pixel.col, pixel.row) == targetColor) {
+          sourceFrame.setPixel(pixel.col, pixel.row, replacementColor);
+          targetFrame.setPixel(pixel.col, pixel.row, replacementColor);
           return true;
         }
         return false;


### PR DESCRIPTION
This makes the bucket fill tool use all layers as reference for what area to fill, not just the one you are on. This is made the default.

The ability to also source only current layer (old behaviour) is preserved and assigned to a modifier key (ctrl)