### PR TITLE
Spelling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,7 +84,7 @@ module.exports = function(grunt) {
       files: [
         // Includes
         'src/js/**/*.js',
-        // Exludes
+        // Excludes
         // TODO: remove this (for now we still get warnings from the lib folder)
         '!src/js/**/lib/**/*.js'
       ],

--- a/src/css/dialogs-cheatsheet.css
+++ b/src/css/dialogs-cheatsheet.css
@@ -103,7 +103,7 @@
   color: white;
 }
 
-.cheatsheet-shorcut-conflict .cheatsheet-key {
+.cheatsheet-shortcut-conflict .cheatsheet-key {
   border-color: red;
   color: red;
 }

--- a/src/css/toolbox.css
+++ b/src/css/toolbox.css
@@ -25,7 +25,7 @@
 }
 
 .toolbox-buttons .button {
-  /* Override border propery on .button elements from form.css */
+  /* Override border property on .button elements from form.css */
   border-style: solid;
   border-color: #333;
   border-width: 0 1px 0 0;

--- a/src/js/controller/FramesListController.js
+++ b/src/js/controller/FramesListController.js
@@ -71,16 +71,16 @@
     var scrollerHeight = scroller.offsetHeight;
     var scrollTop = scroller.scrollTop;
     var scrollerContentHeight = this.previewList.offsetHeight;
-    var treshold = this.container.querySelector('.top-overflow').offsetHeight;
+    var threshold = this.container.querySelector('.top-overflow').offsetHeight;
     var overflowTop = false;
     var overflowBottom = false;
 
     if (scrollerHeight < scrollerContentHeight) {
-      if (scrollTop > treshold) {
+      if (scrollTop > threshold) {
         overflowTop = true;
       }
       var scrollBottom = (scrollerContentHeight - scrollTop) - scrollerHeight;
-      if (scrollBottom > treshold) {
+      if (scrollBottom > threshold) {
         overflowBottom = true;
       }
     }

--- a/src/js/controller/piskel/PiskelController.js
+++ b/src/js/controller/piskel/PiskelController.js
@@ -5,7 +5,7 @@
     if (piskel) {
       this.setPiskel(piskel);
     } else {
-      throw 'A piskel instance is mandatory for instanciating PiskelController';
+      throw 'A piskel instance is mandatory for instantiating PiskelController';
     }
   };
 

--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -107,7 +107,7 @@
   };
 
   /**
-   * Synchronise column and row inputs, called everytime a user input updates one of the
+   * Synchronise column and row inputs, called every time a user input updates one of the
    * two inputs by the SynchronizedInputs widget.
    */
   ns.PngExportController.prototype.onColumnsInput_ = function () {

--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -52,7 +52,7 @@
   };
 
   /**
-   * Initalize all controls related to the spritesheet layout.
+   * Initialize all controls related to the spritesheet layout.
    */
   ns.PngExportController.prototype.initLayoutSection_ = function () {
     var frames = this.piskelController.getFrameCount();

--- a/src/js/database/PiskelDatabase.js
+++ b/src/js/database/PiskelDatabase.js
@@ -84,7 +84,7 @@
         });
         cursor.continue();
       } else {
-        // Cursor consumed all availabled piskels
+        // Cursor consumed all available piskels
         deferred.resolve(piskels);
       }
     };

--- a/src/js/service/keyboard/Shortcuts.js
+++ b/src/js/service/keyboard/Shortcuts.js
@@ -8,7 +8,7 @@
   ns.Shortcuts = {
     /**
      * List of keys that cannot be remapped. Either alternate keys, which are not displayed.
-     * Or really custom shortcuts such as the 1-9 for color palette shorctus
+     * Or really custom shortcuts such as the 1-9 for color palette shortcuts
      */
     FORBIDDEN_KEYS : ['1', '2', '3', '4', '5', '6', '7', '8', '9', '?', 'shift+?',
       'DEL', 'BACK', 'ENTER', 'ctrl+Y', 'ctrl+shift+Z'],

--- a/src/js/tools/drawing/Move.js
+++ b/src/js/tools/drawing/Move.js
@@ -24,7 +24,7 @@
 
   /**
    * The move tool id is used by the ToolController and the BaseSelect and needs to be
-   * easliy accessible
+   * easily accessible
    */
   ns.Move.TOOL_ID = 'tool-move';
 

--- a/src/js/tools/drawing/selection/BaseSelect.js
+++ b/src/js/tools/drawing/selection/BaseSelect.js
@@ -84,7 +84,7 @@
 
   /**
    * If we mouseover the selection draw inside the overlay frame, show the 'move' cursor
-   * instead of the 'select' one. It indicates that we can move the selection by dragndroping it.
+   * instead of the 'select' one. It indicates that we can move the selection by dragndropping it.
    * @override
    */
   ns.BaseSelect.prototype.moveUnactiveToolAt = function(col, row, frame, overlay, event) {

--- a/src/js/utils/ResizeUtils.js
+++ b/src/js/utils/ResizeUtils.js
@@ -8,7 +8,7 @@
      * @param  {Object} options
      *         - width {Number} target width after the resize
      *         - height {Number} target height after the resize
-     *         - resizeContent {Booleam} true of the sprite content should be resized
+     *         - resizeContent {Boolean} true of the sprite content should be resized
      *         - origin {String} should be a valid AnchorWidget origin
      * @return {Piskel} The resized piskel
      */

--- a/src/js/utils/serialization/Deserializer.js
+++ b/src/js/utils/serialization/Deserializer.js
@@ -99,7 +99,7 @@
   };
 
   /**
-   * Backward comptibility only. Create a chunk for layerData objects that only contain
+   * Backward compatibility only. Create a chunk for layerData objects that only contain
    * an single base64PNG without chunk/layout information.
    */
   ns.Deserializer.prototype.normalizeLayerData_ = function (layerData) {

--- a/src/js/widgets/Tabs.js
+++ b/src/js/widgets/Tabs.js
@@ -12,7 +12,7 @@
 
   ns.Tabs.prototype.init = function (container) {
     this.tabListEl = container.querySelector('.tab-list');
-    this.tabContentlEl = container.querySelector('.tab-content');
+    this.tabContentEl = container.querySelector('.tab-content');
     pskl.utils.Event.addEventListener(this.tabListEl, 'click', this.onTabsClicked_, this);
 
     var tab = pskl.UserSettings.get(this.settingsName);
@@ -37,7 +37,7 @@
       this.currentController.destroy();
     }
 
-    this.tabContentlEl.innerHTML = pskl.utils.Template.get(this.tabs[tabId].template);
+    this.tabContentEl.innerHTML = pskl.utils.Template.get(this.tabs[tabId].template);
     this.currentController = new this.tabs[tabId].controller(pskl.app.piskelController, this.parentController);
     this.currentController.init();
     this.currentTab = tabId;

--- a/src/js/widgets/Wizard.js
+++ b/src/js/widgets/Wizard.js
@@ -46,7 +46,7 @@
   };
 
   /**
-   * Transition to the step cirresponding to the provided step name.
+   * Transition to the step corresponding to the provided step name.
    * Animation will be skipped if no current step is displayed.
    */
   ns.Wizard.prototype.goTo = function (stepName) {

--- a/test/js/selection/SelectionManagerTest.js
+++ b/test/js/selection/SelectionManagerTest.js
@@ -168,7 +168,7 @@ describe("SelectionManager suite", function() {
 
     console.log('[SelectionManager] ... cut out of bounds');
     selectionManager.copy({ type: Events.CLIPBOARD_CUT }, createMockCopyEvent());
-    console.log('[SelectionManager] ... check last pixel of midle line was cut in the source frame');
+    console.log('[SelectionManager] ... check last pixel of middle line was cut in the source frame');
     frameEqualsGrid(currentFrame, [
       [B, R, T],
       [R, B, T],

--- a/test/js/service/BackupServiceTest.js
+++ b/test/js/service/BackupServiceTest.js
@@ -91,7 +91,7 @@ describe('BackupService test', function () {
   it('calls create to backup', function (done) {
     preparePiskelMocks(1, 'piskel_name', 'piskel_desc', 'piskel_hash', 'serialized');
 
-    // Set snashot date.
+    // Set snapshot date.
     snapshotDate = 5;
 
     // No snapshots currently saved.


### PR DESCRIPTION
This was developed using https://github.com/jsoref/piskel/tree/spell-check, you can see the runs here: https://github.com/jsoref/piskel/actions/

Historically, I'd run a private spell checking tool against a repository and then just contribute the fixes. And then a couple of years later, I'd come back and repeat the process. To the extent that I manage to get back to a project, that works. But the alternative is actually offering a tool that projects can use to catch errors in advance. If you're interested, I'm happy to make a PR w/ the GitHub action.

I'm still getting used to using this as an Action, especially the idea of telling it to ignore CSS colors -- which resulted in a bit of a goose chase trying to figure out where `sper` and `nvas` were coming from. In normal usage, when one tries to add a misspelling, the tool will annotate the new word and it's pretty obvious.