### PR TITLE
Allocate correct bytecount when serializing

### DIFF
--- a/src/js/utils/serialization/arraybuffer/ArrayBufferSerializer.js
+++ b/src/js/utils/serialization/arraybuffer/ArrayBufferSerializer.js
@@ -42,7 +42,7 @@
    */
 
   ns.ArrayBufferSerializer = {
-    calculateRequiredBytes : function(piskel, framesData) {
+    calculateRequiredBytes : function(piskel, framesData, serializedHiddenFrames) {
       var width = piskel.getWidth();
       var height = piskel.getHeight();
       var descriptorNameLength = piskel.getDescriptor().name.length;
@@ -63,6 +63,9 @@
       // Layers meta
       bytes += 1 * 2;
 
+      // Frames meta
+      bytes += 1 * 2;
+
       /********/
       /* DATA */
       /********/
@@ -71,6 +74,9 @@
 
       // Descriptor description
       bytes += descriptorDescriptionLength * 2;
+
+      // Hidden frames
+      bytes += serializedHiddenFrames.length * 2;
 
       // Layers
       for (var i = 0, layers = piskel.getLayers(); i < layers.length; i++) {


### PR DESCRIPTION
The size of buffer calculated for serializing data was not accounting for hidden frame data. This would cause the buffer to overflow and the bottoms of images to sometimes be truncated when using undo. Changed calculateRequiredBytes to match what's used the serialize function.

This should fix: #889, #893, #925