### PR TITLE
Fix frame-preview-toggle when moving a frame

### DIFF
--- a/src/js/controller/piskel/PiskelController.js
+++ b/src/js/controller/piskel/PiskelController.js
@@ -214,7 +214,10 @@
           return index + 1;
         }
       }
-    });
+
+      return index;
+    }).sort();
+
   };
 
   ns.PiskelController.prototype.hasVisibleFrameAt = function (index) {


### PR DESCRIPTION
The hiddenFrames list is not updated correctly when a frame is moved.
Unmoved frames are mapped incorrectly and result in "undefined" entries
in the list. The resulting list is also left unsorted. Changed to make unmoved
entries still return a value when mapping and sorted the list after frames
have moved.