### PR TITLE
Further customization of grid spacing

### DIFF
--- a/src/css/settings-application.css
+++ b/src/css/settings-application.css
@@ -73,26 +73,9 @@
   flex-shrink: 0;
 }
 
-.grid-spacing-container .size-picker-option[data-size='1'] {
-  padding: 7px;
-}
-.grid-spacing-container .size-picker-option[data-size='2'] {
-  padding: 6px;
-}
-.grid-spacing-container .size-picker-option[data-size='4'] {
-  padding: 5px;
-}
-.grid-spacing-container .size-picker-option[data-size='8'] {
-  padding: 4px;
-}
-.grid-spacing-container .size-picker-option[data-size='16'] {
-  padding: 3px;
-}
-.grid-spacing-container .size-picker-option[data-size='32'] {
-  padding: 2px;
-}
-.grid-spacing-container .size-picker-option[data-size='64'] {
-  padding: 1px;
+.grid-spacing-input-container {
+  display:inline-block;
+  padding: 7px 5px;
 }
 
 .settings-item-grid-size .size-picker-option,

--- a/src/js/controller/settings/preferences/GridPreferencesController.js
+++ b/src/js/controller/settings/preferences/GridPreferencesController.js
@@ -22,7 +22,6 @@
     this.piskelController = piskelController;
     this.preferencesController = preferencesController;
     this.sizePicker = new pskl.widgets.SizePicker(this.onSizePickerChanged_.bind(this));
-    this.spacingPicker = new pskl.widgets.SizePicker(this.onSpacingPickerChanged_.bind(this));
   };
 
   pskl.utils.inherit(ns.GridPreferencesController, pskl.controller.settings.AbstractSettingController);
@@ -42,10 +41,9 @@
     this.sizePicker.setSize(gridWidth);
 
     //Grid Spacing
-    var gridSpacing = pskl.UserSettings.get(pskl.UserSettings.GRID_SPACING);
-    this.spacingPicker.init(document.querySelector('.grid-spacing-container'));
-    this.spacingPicker.setSize(gridSpacing);
-
+    var gridSpacingInput = document.querySelector('.grid-spacing-input');
+    gridSpacingInput.value = pskl.UserSettings.get(pskl.UserSettings.GRID_SPACING);
+    this.addEventListener(gridSpacingInput, 'change', this.onGridSpacingChange_);
     // Grid color
     var colorListItemTemplate = pskl.utils.Template.get('color-list-item-template');
 
@@ -74,7 +72,6 @@
 
   ns.GridPreferencesController.prototype.destroy = function () {
     this.sizePicker.destroy();
-    this.spacingPicker.destroy();
     this.superclass.destroy.call(this);
   };
 
@@ -82,8 +79,14 @@
     pskl.UserSettings.set(pskl.UserSettings.GRID_WIDTH, size);
   };
 
-  ns.GridPreferencesController.prototype.onSpacingPickerChanged_ = function (size) {
-    pskl.UserSettings.set(pskl.UserSettings.GRID_SPACING, size);
+  ns.GridPreferencesController.prototype.onGridSpacingChange_ = function (evt) {
+    var target = evt.target;
+    var gridSpacing = parseInt(target.value, 10);
+    if (gridSpacing && !isNaN(gridSpacing)) {
+      pskl.UserSettings.set(pskl.UserSettings.GRID_SPACING, gridSpacing);
+    } else {
+      target.value = pskl.UserSettings.get(pskl.UserSettings.GRID_SPACING);
+    };
   };
 
   ns.GridPreferencesController.prototype.onEnableGridChange_ = function (evt) {

--- a/src/templates/settings/preferences/grid.html
+++ b/src/templates/settings/preferences/grid.html
@@ -19,23 +19,11 @@
           title="4px" rel="tooltip" data-placement="top" data-size="4"></div>
       </div>
     </div>
-    <div class="settings-item settings-item-grid-spacing">
-      <label>Grid spacing</label>
-      <div class="grid-spacing-container size-picker-container">
-        <div class="size-picker-option"
-          title="1px" rel="tooltip" data-placement="top" data-size="1"></div>
-        <div class="size-picker-option"
-          title="2px" rel="tooltip" data-placement="top" data-size="2"></div>
-        <div class="size-picker-option"
-          title="4px" rel="tooltip" data-placement="top" data-size="4"></div>
-        <div class="size-picker-option"
-          title="8px" rel="tooltip" data-placement="top" data-size="8"></div>
-        <div class="size-picker-option"
-          title="16px" rel="tooltip" data-placement="top" data-size="16"></div>
-        <div class="size-picker-option"
-          title="32px" rel="tooltip" data-placement="top" data-size="32"></div>
-        <div class="size-picker-option"
-          title="64px" rel="tooltip" data-placement="top" data-size="64"></div>
+    <div class="resize-section settings-item">
+      <label class="resize-section-title">Grid spacing</label>
+      <div class="grid-spacing-input-container">
+        <input type="text" class="textfield resize-size-field grid-spacing-input" autocomplete="off"/>
+        <span>px</span>
       </div>
     </div>
     <div class="settings-item settings-item-grid-color">


### PR DESCRIPTION
Currently, the grid spacing is limited to a set number of widths: 1, 2, 4, 8, 16, 32, or 64 pixels. The grid spacing with these proposed changes can be any integer value. Thus the user is not restricted in his grid spacing, but is free to choose its own. The proposed changes can be seen on the left, while the original can be seen on the right of the image.

<a href="https://imgur.com/9dg8jWu"><img src="https://i.imgur.com/9dg8jWu.png" title="source: imgur.com" /></a>
