### PR TITLE
fix #984 The file extension ".png" is doubled when exporting a frame

### DIFF
--- a/src/js/controller/settings/exportimage/PngExportController.js
+++ b/src/js/controller/settings/exportimage/PngExportController.js
@@ -239,7 +239,7 @@
       canvas = pskl.utils.ImageResizer.resize(canvas, canvas.width * zoom, canvas.height * zoom, false);
     }
 
-    var fileName = name + '-' + (frameIndex + 1) + '.png';
+    var fileName = name + '-' + (frameIndex + 1);
     this.downloadCanvas_(canvas, fileName);
   };
 })();


### PR DESCRIPTION
As it's been mentioned on issue #984 , **The file extension ".png" is doubled when exporting a frame**.
> ### Steps to reproduce the bug
> 
>     1. Export a frame using "Single frame as a PNG file"
> 
>     2. If the sprite has the title "MyTitle", the frame is exported with the filename "MyTitle-1.png.png"
> 
> 