### PR TITLE
Make merged layer take name of lower layer

### DIFF
--- a/src/js/utils/LayerUtils.js
+++ b/src/js/utils/LayerUtils.js
@@ -17,7 +17,7 @@
         var otherFrame = framesB[index];
         mergedFrames.push(pskl.utils.FrameUtils.merge([otherFrame, frame]));
       });
-      var mergedLayer = pskl.model.Layer.fromFrames(layerA.getName(), mergedFrames);
+      var mergedLayer = pskl.model.Layer.fromFrames(layerB.getName(), mergedFrames);
       return mergedLayer;
     },
 


### PR DESCRIPTION
Most of the time when merging layers, you'll want to keep the name of the Bottom layer. This saves users the trouble of having to rename the layer.