### PR TITLE
fix: fixed click events with othen dom didn't take effect on safari  mobile

### DIFF
--- a/src/js/controller/DrawingController.js
+++ b/src/js/controller/DrawingController.js
@@ -85,12 +85,12 @@
       this.container.addEventListener('wheel', this.onMousewheel_.bind(this));
     }
 
-    window.addEventListener('mouseup', this.onMouseup_.bind(this));
-    window.addEventListener('mousemove', this.onMousemove_.bind(this));
-    window.addEventListener('keyup', this.onKeyup_.bind(this));
-    window.addEventListener('touchstart', this.onTouchstart_.bind(this));
-    window.addEventListener('touchmove' , this.onTouchmove_.bind(this));
-    window.addEventListener('touchend', this.onTouchend_.bind(this));
+    this.container.addEventListener('mouseup', this.onMouseup_.bind(this));
+    this.container.addEventListener('mousemove', this.onMousemove_.bind(this));
+    this.container.addEventListener('keyup', this.onKeyup_.bind(this));
+    this.container.addEventListener('touchstart', this.onTouchstart_.bind(this));
+    this.container.addEventListener('touchmove' , this.onTouchmove_.bind(this));
+    this.container.addEventListener('touchend', this.onTouchend_.bind(this));
 
     // Deactivate right click:
     document.body.addEventListener('contextmenu', this.onCanvasContextMenu_.bind(this));


### PR DESCRIPTION
fixed click events didn't take effect on safari mobile (ios/ipad)
[#900]
[#793]
[#768]
[#858]


tocuh events did't need addEventListener in window , just only addEventListener in canvans container.

before that, when touchstart and touchend was both addEventListener in window , then it affect the click events of other elements.


