### PR TITLE
Loop through the frames with up and down keys

### DIFF
--- a/src/js/controller/piskel/PiskelController.js
+++ b/src/js/controller/piskel/PiskelController.js
@@ -243,16 +243,18 @@
 
   ns.PiskelController.prototype.selectNextFrame = function () {
     var nextIndex = this.currentFrameIndex + 1;
-    if (nextIndex < this.getFrameCount()) {
-      this.setCurrentFrameIndex(nextIndex);
+    if (nextIndex >= this.getFrameCount()) {
+      nextIndex = 0;
     }
+    this.setCurrentFrameIndex(nextIndex);
   };
 
   ns.PiskelController.prototype.selectPreviousFrame = function () {
     var nextIndex = this.currentFrameIndex - 1;
-    if (nextIndex >= 0) {
-      this.setCurrentFrameIndex(nextIndex);
+    if (nextIndex < 0) {
+      nextIndex = this.getFrameCount() - 1;
     }
+    this.setCurrentFrameIndex(nextIndex);
   };
 
   ns.PiskelController.prototype.setCurrentLayerIndex = function (index) {


### PR DESCRIPTION
The modified code allows the user to loop through the frames of an animation using the up and down keys, ensuring that they don't get stuck at the start or end of the animation.

This behavior is often desirable in animation or slideshow applications, as it provides a more seamless user experience.

The code checks if the user is at the beginning or end of the animation and loops back to the other end when they try to go beyond those limits.