### PR TITLE
Add branding color to FPS slider

### DIFF
--- a/src/css/toolbox-animated-preview.css
+++ b/src/css/toolbox-animated-preview.css
@@ -52,12 +52,40 @@
   line-height: 26px;
 }
 
+/* change ".range-fps" to "input[type='range']" to make universal */
 .range-fps {
   overflow: hidden;
   width: 100px;
   height : 26px;
   margin : 0;
   box-sizing: border-box;
+  accent-color:gold; /* fallback */
+  accent-color: var(--highlight-color);
+  cursor: pointer;
+}
+.range-fps::-webkit-slider-thumb{
+  cursor:grab;
+}
+.range-fps::-moz-range-thumb{
+  cursor:grab;
+}
+.range-fps::-ms-thumb{
+  cursor:grab;
+}
+
+/* moving slider */
+.range-fps:active,
+.range-fps:focus-within{
+  cursor:grabbing;
+}
+.range-fps::-webkit-slider-thumb:active{
+  cursor:grabbing;
+}
+.range-fps::-moz-range-thumb:active{
+  cursor:grabbing;
+}
+.range-fps::-ms-thumb:active{
+  cursor:grabbing;
 }
 
 .preview-toggle-onion-skin {


### PR DESCRIPTION
FPS slider currently uses the default browser styles (looking inconsistent with Piskel UI). This commit includes CSS styles that leverage the `--highlight-color` variable instead. This PR also includes styles for slider UI such as "grabbing" the slider and hovering over the slider.

These styles can easily be implemented to cover ALL range inputs by updating the selector ".range-fps" to "input[type='range']". This was not done with this PR as I am unsure of the intention of other sliders across the site (or even if there are any others).