### PR TITLE
fix(build): Remove reference to non-existent ImageUploadService.js

### DIFF
--- a/src/piskel-script-list.js
+++ b/src/piskel-script-list.js
@@ -204,7 +204,6 @@
   "js/service/keyboard/Shortcuts.js",
   "js/service/keyboard/ShortcutService.js",
   "js/service/ImportService.js",
-  "js/service/ImageUploadService.js",
   "js/service/ClipboardService.js",
   "js/service/CurrentColorsService.js",
   "js/service/FileDropperService.js",


### PR DESCRIPTION
The ImageUploadService.js file was referenced in piskel-script-list.js but does not exist in the codebase, causing 404 errors during development build loading.

This commit removes the reference to fix the development server loading issues and eliminate console errors.