### PR TITLE
Add drawing support across tiles in seamless mode

### DIFF
--- a/src/js/model/Frame.js
+++ b/src/js/model/Frame.js
@@ -107,6 +107,7 @@
   };
 
   ns.Frame.prototype.setPixel = function (x, y, color) {
+    if(isNaN(x) || isNaN(y)) return;
     if (this.containsPixel(x, y)) {
       var index = y * this.width + x;
       var p = this.pixels[index];
@@ -116,6 +117,10 @@
         this.pixels[index] = color || pskl.utils.colorToInt(Constants.TRANSPARENT_COLOR);
         this.version++;
       }
+    } else if (pskl.UserSettings.get('SEAMLESS_MODE')) {
+      var tiledX = ((x % this.width) + this.width) % this.width;
+      var tiledY = ((y % this.height) + this.height) % this.height;
+      this.setPixel(tiledX , tiledY , color);
     }
   };
 

--- a/src/js/tools/drawing/BaseTool.js
+++ b/src/js/tools/drawing/BaseTool.js
@@ -31,7 +31,7 @@
   };
 
   ns.BaseTool.prototype.moveUnactiveToolAt = function (col, row, frame, overlay, event) {
-    if (overlay.containsPixel(col, row)) {
+    if (overlay.containsPixel(col, row) || pskl.UserSettings.get('SEAMLESS_MODE')) {
       this.updateHighlightedPixel(frame, overlay, col, row);
     } else {
       this.hideHighlightedPixel(overlay);

--- a/src/js/tools/drawing/Circle.js
+++ b/src/js/tools/drawing/Circle.js
@@ -40,10 +40,13 @@
     var y;
     var angle;
     var r;
+    var v;
 
     if (penSize == 1) {
       for (x = coords.x0 ; x <= xC ; x++) {
-        angle = Math.acos((x - xC) / rX);
+        v = (x - xC) / rX;
+        if (v < -1 || v > 1) continue;
+        angle = Math.acos(v);
         y = Math.round(rY * Math.sin(angle) + yC);
         pixels.push([x - evenX, y]);
         pixels.push([x - evenX, 2 * yC - y - evenY]);
@@ -51,7 +54,9 @@
         pixels.push([2 * xC - x, 2 * yC - y - evenY]);
       }
       for (y = coords.y0 ; y <= yC ; y++) {
-        angle = Math.asin((y - yC) / rY);
+        v = (y - yC) / rY
+        if (v < -1 || v > 1) continue;
+        angle = Math.asin(v);
         x = Math.round(rX * Math.cos(angle) + xC);
         pixels.push([x, y - evenY]);
         pixels.push([2 * xC - x - evenX, y - evenY]);

--- a/src/js/tools/drawing/ColorPicker.js
+++ b/src/js/tools/drawing/ColorPicker.js
@@ -18,8 +18,16 @@
    * @override
    */
   ns.ColorPicker.prototype.applyToolAt = function(col, row, frame, overlay, event) {
-    if (frame.containsPixel(col, row)) {
-      var sampledColor = pskl.utils.intToColor(frame.getPixel(col, row));
+    var targetCol = col;
+    var targetRow = row;
+
+    if (pskl.UserSettings.get('SEAMLESS_MODE')) {
+      targetCol = ((col % frame.getWidth()) + frame.getWidth()) % frame.getWidth();
+      targetRow = ((row % frame.getHeight()) + frame.getHeight()) % frame.getHeight();
+    }
+
+    if (frame.containsPixel(targetCol, targetRow)) {
+      var sampledColor = pskl.utils.intToColor(frame.getPixel(targetCol, targetRow));
       if (pskl.app.mouseStateService.isLeftButtonPressed()) {
         $.publish(Events.SELECT_PRIMARY_COLOR, [sampledColor]);
       } else if (pskl.app.mouseStateService.isRightButtonPressed()) {

--- a/src/js/tools/drawing/ColorSwap.js
+++ b/src/js/tools/drawing/ColorSwap.js
@@ -22,8 +22,16 @@
    * @override
    */
   ns.ColorSwap.prototype.applyToolAt = function(col, row, frame, overlay, event) {
-    if (frame.containsPixel(col, row)) {
-      var oldColor = frame.getPixel(col, row);
+    var targetCol = col;
+    var targetRow = row;
+  
+    if (pskl.UserSettings.get('SEAMLESS_MODE')) {
+      targetCol = ((col % frame.getWidth()) + frame.getWidth()) % frame.getWidth();
+      targetRow = ((row % frame.getHeight()) + frame.getHeight()) % frame.getHeight();
+    }
+
+    if (frame.containsPixel(targetCol, targetRow)) {
+      var oldColor = frame.getPixel(targetCol, targetRow);
       var newColor = this.getToolColor();
 
       var allLayers = pskl.utils.UserAgent.isMac ?  event.metaKey : event.ctrlKey;

--- a/src/js/tools/drawing/Lighten.js
+++ b/src/js/tools/drawing/Lighten.js
@@ -29,9 +29,16 @@
   ns.Lighten.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     this.previousCol = col;
     this.previousRow = row;
+    var targetCol = col;
+    var targetRow = row;
+  
+    if (pskl.UserSettings.get('SEAMLESS_MODE')) {
+      targetCol = ((col % frame.getWidth()) + frame.getWidth()) % frame.getWidth();
+      targetRow = ((row % frame.getHeight()) + frame.getHeight()) % frame.getHeight();
+    }
 
     var penSize = pskl.app.penSizeService.getPenSize();
-    var points = pskl.PixelUtils.resizePixel(col, row, penSize);
+    var points = pskl.PixelUtils.resizePixel(targetCol, targetRow, penSize);
     points.forEach(function (point) {
       var modifiedColor = this.getModifiedColor_(point[0], point[1], frame, overlay, event);
       this.draw(modifiedColor, point[0], point[1], frame, overlay);

--- a/src/js/tools/drawing/PaintBucket.js
+++ b/src/js/tools/drawing/PaintBucket.js
@@ -19,7 +19,15 @@
    */
   ns.PaintBucket.prototype.applyToolAt = function(col, row, frame, overlay, event) {
     var color = this.getToolColor();
-    pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(frame, col, row, color);
+    var targetCol = col;
+    var targetRow = row;
+    
+    if (pskl.UserSettings.get('SEAMLESS_MODE')) {
+      targetCol = ((col % frame.getWidth()) + frame.getWidth()) % frame.getWidth();
+      targetRow = ((row % frame.getHeight()) + frame.getHeight()) % frame.getHeight();
+    }
+
+    pskl.PixelUtils.paintSimilarConnectedPixelsFromFrame(frame, targetCol, targetRow, color);
 
     this.raiseSaveStateEvent({
       col : col,

--- a/src/js/utils/PixelUtils.js
+++ b/src/js/utils/PixelUtils.js
@@ -189,6 +189,11 @@
         for (var i = 0; i < 4; i++) {
           var nextCol = currentItem.col + dx[i];
           var nextRow = currentItem.row + dy[i];
+          
+          if (pskl.UserSettings.get('SEAMLESS_MODE')) {
+            nextCol = ((nextCol % frame.getWidth()) + frame.getWidth()) % frame.getWidth();
+            nextRow = ((nextRow % frame.getHeight()) + frame.getHeight()) % frame.getHeight();
+          }
           try {
             var connectedPixel = {'col': nextCol, 'row': nextRow};
             var isValid = pixelVisitor(connectedPixel);


### PR DESCRIPTION
As highlighted by several users, it is not possible to draw outside the main canvas in tiled mode. This commit fixes the issue for all drawing tools by remapping the drawing point coordinates to the main canvas when the user tries to draw outside it.

The commit also fixes a bug in the ellipse tool code by normalizing the input values to acos and asin, preventing pixels from having NaN coordinates.