### PR TITLE
Explicitly disable bluetooth for macos with chromium-args for nw.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "width": 1000,
     "height": 700
   },
+  "chromium-args": "--disable-features=WebBluetooth,WebBluetoothNewPermissionsBackend,WebBluetoothGetDevices,WebBluetoothScanning,WebBluetoothWatchAdvertisements",
   "dependencies": {
     "minimist": "^1.2.5"
   }


### PR DESCRIPTION
Fixes #1143

Locally bluetooth permission doesn't pop up and that's because it's not downloaded online, which would actually trigger some security checks / bluetooth on Mac's end.

nw.js uses chromium and provides `chromium-args` for passing flags to config certain features, including bluetooth.

- https://docs.nwjs.io/References/Manifest%20Format/#chromium-args: chromium-args usage
- https://github.com/nwjs/chromium.src/blob/nw18/content/public/common/content_switches.cc: flags that nw.js accepts for chromium
- https://niek.github.io/chrome-features/?utm_source=chatgpt.com: list of web features