### PR TITLE
chore(dev): fix npm run dev ImageUploadService.js not found

### DIFF
--- a/src/piskel-script-list.js
+++ b/src/piskel-script-list.js
@@ -204,7 +204,6 @@
   "js/service/keyboard/Shortcuts.js",
   "js/service/keyboard/ShortcutService.js",
   "js/service/ImportService.js",
-  "js/service/ImageUploadService.js",
   "js/service/ClipboardService.js",
   "js/service/CurrentColorsService.js",
   "js/service/FileDropperService.js",


### PR DESCRIPTION
### Issue

As a developer, when I run `npm run dev`, the app does not load and I see in the browser console this error:

```
GET http://localhost:9901/js/service/ImageUploadService.js net::ERR_ABORTED 404 (Not Found)
```

And indeed the file does not exist anymore. It has been removed [here](https://github.com/ledenis/piskel/commit/91a5a9b5b6dc5fec2881ff5f30d0ca45e354f5c8).

### The fix

Remove reference to this file in `piskel-script-list.js`