### PR TITLE
feat: remove text references to the gallery

### DIFF
--- a/src/templates/dialogs/browse-backups.html
+++ b/src/templates/dialogs/browse-backups.html
@@ -18,7 +18,7 @@
         If you forgot to save your work or if Piskel crashed, try to restore one of the automatically backed up sessions below (up to 10 sessions).
         <br/>
         <br/>
-        Backups may be erased without notice, so try to save your work to a file or to your gallery as soon as you can.
+        Backups may be erased without notice, so try to save your work to a file as soon as you can.
       </div>
     </div>
     <div class="session-list">

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -16,7 +16,7 @@
   <div
     data-setting="save"
     class="tool-icon  icon-settings-save-white"
-    title="<span class='highlight'>SAVE</span></br>Save to your gallery, save locally<br/>or export as a file"
+    title="<span class='highlight'>SAVE</span></br>Save locally or export as a file"
     rel="tooltip" data-placement="left" >
   </div>
 


### PR DESCRIPTION
The gallery has been removed, but there are still text references to it:
* in the Save button tooltip
* in the Browse backups dialog

This PR removes them from there.